### PR TITLE
Don't build lcidlc on emscripten or iOS platforms

### DIFF
--- a/lcidlc/lcidlc.gyp
+++ b/lcidlc/lcidlc.gyp
@@ -52,6 +52,16 @@
                 '<(SHARED_INTERMEDIATE_DIR)/LCIDLC/EncodedJavaSupport.c',
                 '<(SHARED_INTERMEDIATE_DIR)/LCIDLC/EncodedSupport.c',
 			],
+			
+			'conditions':
+			[
+				[
+					# Don't compile on iOS or emscripten
+					'OS == "ios" or OS == "emscripten"',
+					{
+						'type': 'none',
+					},
+			],
 		},
         {
             'target_name': 'encode_support',


### PR DESCRIPTION
`lcidlc` isn't needed for either of these operating systems.
